### PR TITLE
Save LOAD CSV exploration notebook

### DIFF
--- a/examples/notebooks/exploration/TEST_LOAD_CSV.ipynb
+++ b/examples/notebooks/exploration/TEST_LOAD_CSV.ipynb
@@ -1,0 +1,943 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b9ff8dbf",
+   "metadata": {},
+   "source": [
+    "# TEST — LOAD CSV\n",
+    "\n",
+    "Exploratory notebook to understand how `LOAD CSV` works in TuringDB v1.23.\n",
+    "\n",
+    "## Key finding\n",
+    "\n",
+    "`LOAD CSV` in TuringDB **is NOT the same as `LOAD JSONL`**. It does not create a self-contained graph from a file. It is a row-based reader inspired by Neo4j's `LOAD CSV`, used inside a write transaction.\n",
+    "\n",
+    "### Correct pattern\n",
+    "\n",
+    "```python\n",
+    "client.query('create graph my_graph')\n",
+    "client.set_graph('my_graph')\n",
+    "client.new_change()                          # open write transaction\n",
+    "client.query(\"LOAD CSV 'file.csv' WITH HEADERS AS row CREATE (n:Label)\")\n",
+    "client.query('CHANGE SUBMIT')               # commit\n",
+    "client.checkout()                           # back to main branch\n",
+    "```\n",
+    "\n",
+    "### What works\n",
+    "| Feature | Status |\n",
+    "|---|---|\n",
+    "| `RETURN row.ColumnName` | ✅ read CSV values |\n",
+    "| `CREATE (n:Label)` | ✅ creates one node per row |\n",
+    "| `WITH HEADERS AS row` | ✅ gives named column access |\n",
+    "\n",
+    "### What does NOT work\n",
+    "| Feature | Status |\n",
+    "|---|---|\n",
+    "| `CREATE (n:Label {prop: row.Col})` | ❌ internal assertion error |\n",
+    "| `SET n.prop = row.Col` | ❌ type `Invalid` incompatible |\n",
+    "| `WHERE row.Col = 'value'` | ❌ parse error |\n",
+    "| `MERGE` | ❌ not implemented |\n",
+    "| `LOAD CSV 'file' AS graph_name` (LOAD JSONL-style) | ❌ parse error |\n",
+    "\n",
+    "**Conclusion:** LOAD CSV cannot transfer CSV values into node/edge properties in v1.23. For data loading, continue using **LOAD JSONL**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba8df3a5",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "9c3cd81b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TuringDB connected\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import shutil\n",
+    "from pathlib import Path\n",
+    "import turingdb\n",
+    "from IPython.display import display\n",
+    "\n",
+    "client = turingdb.TuringDB()\n",
+    "print('TuringDB connected')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7d6a3522",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TuringDB data dir: /home/ubuntu/.turing/data\n",
+      "Exists: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# TuringDB data directory (paths in LOAD CSV are relative to this)\n",
+    "DATA_DIR = Path.home() / '.turing' / 'data'\n",
+    "print(f'TuringDB data dir: {DATA_DIR}')\n",
+    "print(f'Exists: {DATA_DIR.exists()}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "0dc23164",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Copied healthcare_dataset.csv -> /home/ubuntu/.turing/data/healthcare_dataset.csv\n",
+      "  Copied TfL_london_transport_tube.csv -> /home/ubuntu/.turing/data/tfl_tube.csv\n",
+      "  Copied TfL_london_transport_tube_stations.csv -> /home/ubuntu/.turing/data/tfl_stations.csv\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Copy the CSVs we want to test into the TuringDB data directory\n",
+    "REPO_DATA = Path(os.getcwd()) / 'data'\n",
+    "\n",
+    "csv_files = {\n",
+    "    'healthcare_dataset.csv':          REPO_DATA / 'healthcare_dataset'     / 'healthcare_dataset.csv',\n",
+    "    'tfl_tube.csv':                    REPO_DATA / 'london_transport_TfL'   / 'TfL_london_transport_tube.csv',\n",
+    "    'tfl_stations.csv':                REPO_DATA / 'london_transport_TfL'   / 'TfL_london_transport_tube_stations.csv',\n",
+    "}\n",
+    "\n",
+    "for dest_name, src_path in csv_files.items():\n",
+    "    dest = DATA_DIR / dest_name\n",
+    "    shutil.copy(src_path, dest)\n",
+    "    print(f'  Copied {src_path.name} -> {dest}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0eb15c27",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## What works: RETURN row values\n",
+    "\n",
+    "`LOAD CSV 'file' WITH HEADERS AS row RETURN row.ColumnName` works — useful for inspecting a CSV without importing it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "3f6a270f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>row.Name</th>\n",
+       "      <th>row.Age</th>\n",
+       "      <th>row.Gender</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Bobby JacksOn</td>\n",
+       "      <td>30</td>\n",
+       "      <td>Male</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>LesLie TErRy</td>\n",
+       "      <td>62</td>\n",
+       "      <td>Male</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>DaNnY sMitH</td>\n",
+       "      <td>76</td>\n",
+       "      <td>Female</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>andrEw waTtS</td>\n",
+       "      <td>28</td>\n",
+       "      <td>Female</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>adrIENNE bEll</td>\n",
+       "      <td>43</td>\n",
+       "      <td>Female</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        row.Name row.Age row.Gender\n",
+       "0  Bobby JacksOn      30       Male\n",
+       "1   LesLie TErRy      62       Male\n",
+       "2    DaNnY sMitH      76     Female\n",
+       "3   andrEw waTtS      28     Female\n",
+       "4  adrIENNE bEll      43     Female"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Inspect healthcare CSV — no graph context needed\n",
+    "result = client.query(\"LOAD CSV 'healthcare_dataset.csv' WITH HEADERS AS row RETURN row.Name, row.Age, row.Gender LIMIT 5\")\n",
+    "display(result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "6aebf439",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>row.Line</th>\n",
+       "      <th>row.From_Station</th>\n",
+       "      <th>row.To_Station</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Bakerloo</td>\n",
+       "      <td>Elephant &amp; Castle</td>\n",
+       "      <td>Lambeth North</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Bakerloo</td>\n",
+       "      <td>Lambeth North</td>\n",
+       "      <td>Waterloo</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Bakerloo</td>\n",
+       "      <td>Waterloo</td>\n",
+       "      <td>Embankment</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Bakerloo</td>\n",
+       "      <td>Embankment</td>\n",
+       "      <td>Charing Cross</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Bakerloo</td>\n",
+       "      <td>Charing Cross</td>\n",
+       "      <td>Piccadilly Circus</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   row.Line    row.From_Station     row.To_Station\n",
+       "0  Bakerloo  Elephant & Castle       Lambeth North\n",
+       "1  Bakerloo       Lambeth North          Waterloo \n",
+       "2  Bakerloo           Waterloo          Embankment\n",
+       "3  Bakerloo          Embankment     Charing Cross \n",
+       "4  Bakerloo      Charing Cross   Piccadilly Circus"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Works on edge-list CSVs too\n",
+    "result = client.query(\"LOAD CSV 'tfl_tube.csv' WITH HEADERS AS row RETURN row.Line, row.From_Station, row.To_Station LIMIT 5\")\n",
+    "display(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6baba53",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## What works: CREATE labeled nodes (no properties)\n",
+    "\n",
+    "`LOAD CSV ... CREATE (n:Label)` creates one node per CSV row inside a write transaction.\n",
+    "The nodes have a label but **no properties** — values from `row` cannot be transferred."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "1d5da508",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Done\n",
+      "CPU times: user 6.68 ms, sys: 0 ns, total: 6.68 ms\n",
+      "Wall time: 97.5 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "# Create a graph and load healthcare CSV (55 500 rows)\n",
+    "# test_healthcare_csv was already created in a previous run — reuse it, clear it first\n",
+    "client.set_graph('test_healthcare_csv')\n",
+    "client.new_change()\n",
+    "client.query('MATCH (n) DETACH DELETE n')\n",
+    "client.query('CHANGE SUBMIT')\n",
+    "client.checkout()\n",
+    "\n",
+    "client.new_change()\n",
+    "client.query(\"LOAD CSV 'healthcare_dataset.csv' WITH HEADERS AS row CREATE (n:Patient)\")\n",
+    "client.query('CHANGE SUBMIT')\n",
+    "client.checkout()\n",
+    "print('Done')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "8b10cdb5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Node count:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>count(n)</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>55500</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   count(n)\n",
+       "0     55500"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Labels:\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>label</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>Patient</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>Station</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   id    label\n",
+       "0   0  Patient\n",
+       "1   1  Station"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Property types (expected: empty):\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>propertyType</th>\n",
+       "      <th>valueType</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "Empty DataFrame\n",
+       "Columns: [id, propertyType, valueType]\n",
+       "Index: []"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# 55 500 Patient nodes created — one per CSV row\n",
+    "print('Node count:')\n",
+    "display(client.query('MATCH (n) RETURN count(n)'))\n",
+    "\n",
+    "# Label is correct\n",
+    "print('\\nLabels:')\n",
+    "display(client.query('CALL db.labels()'))\n",
+    "\n",
+    "# But NO properties — row values were not transferred\n",
+    "print('\\nProperty types (expected: empty):')\n",
+    "display(client.query('CALL db.propertyTypes()'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cdb87306-10f6-4062-9a64-499ee2897a55",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ea4c5f8e-3cb5-43fb-a8fe-5aa1b080368b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No result found\n",
+      "CPU times: user 0 ns, sys: 1.67 ms, total: 1.67 ms\n",
+      "Wall time: 1.34 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "# CALL propertyTypes() - returns a column of all the different node and edge properties and their types in the database\n",
+    "command = \"\"\"\n",
+    "CALL db.propertyTypes()\n",
+    "\"\"\"\n",
+    "df_propertyTypes = client.query(command)\n",
+    "if df_propertyTypes.empty:\n",
+    "    print(\"No result found\")\n",
+    "else:\n",
+    "    display(df_propertyTypes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "cca94e45-4de6-4b67-a1f0-e5a47241a8e6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Node properties: []\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Get node properties\n",
+    "nodes_properties = df_propertyTypes[\"propertyType\"].values.tolist()\n",
+    "print(f\"Node properties: {nodes_properties}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "4ff6d756-0d50-4c6c-a520-733a89338c2e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>label</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>Patient</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>Station</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   id    label\n",
+       "0   0  Patient\n",
+       "1   1  Station"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1.21 ms, sys: 3.91 ms, total: 5.12 ms\n",
+      "Wall time: 4.72 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "# CALL labels () - returns a column of all the different node labels\n",
+    "command = \"\"\"\n",
+    "CALL db.labels()\n",
+    "\"\"\"\n",
+    "df_labels = client.query(command)\n",
+    "if df_labels.empty:\n",
+    "    print(\"No result found\")\n",
+    "else:\n",
+    "    display(df_labels)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "93e3922b-a435-4de7-8d82-2484eecb2c3d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No result found\n",
+      "CPU times: user 1.91 ms, sys: 0 ns, total: 1.91 ms\n",
+      "Wall time: 1.65 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "# CALL edgeTypes() - returns a column of all the different edge types (edge equivalent of node labels)\n",
+    "command = \"\"\"\n",
+    "CALL db.edgeTypes()\n",
+    "\"\"\"\n",
+    "df_edgeTypes = client.query(command)\n",
+    "if df_edgeTypes.empty:\n",
+    "    print(\"No result found\")\n",
+    "else:\n",
+    "    display(df_edgeTypes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7cefdf0e-2b2e-4f12-91af-4de88ccd81d5",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "8ae856f6-e943-4edf-bc53-b12a9cf60a77",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>count(e)</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   count(e)\n",
+       "0         0"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "client.query(\"MATCH (n)-[e]->(m) RETURN count(e)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "45ac73ae-f1da-4321-8ce6-73194ec1653f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e66a6429-4d1c-420a-ad7e-4ebaeb0e36a1",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9052a237-16ca-4d68-8ffd-7fa0d8a97641",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f71015fd",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Limitations\n",
+    "\n",
+    "### CREATE with properties — fails (internal assertion error)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "5c1fcf95",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Expected error: EXEC_ERROR: Unexpected exception: Internal Error: The assertion 'casted' failed at /home/runner/work/turingdb/turingdb/query/pipeline/processors/WriteProcessor.cpp:83\n",
+      "Could not get constant property value.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    client.new_change()\n",
+    "    client.query(\"LOAD CSV 'healthcare_dataset.csv' WITH HEADERS AS row CREATE (n:Patient {name: row.Name})\")\n",
+    "    client.query('CHANGE SUBMIT')\n",
+    "    client.checkout()\n",
+    "except Exception as e:\n",
+    "    client.checkout()\n",
+    "    print(f'Expected error: {e}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35a4729d",
+   "metadata": {},
+   "source": [
+    "### SET n.prop = row.col — fails (type `Invalid` incompatible)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "8da7a800",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Expected error: ANALYZE_ERROR: -------* Query error\n",
+      "     1 | LOAD CSV 'tfl_tube.csv' WITH HEADERS AS row CREATE (n:Station) SET n.type = row.Line\n",
+      "       |                                                                    ^^^^^^\n",
+      "-------* Property type 'type' is invalid\n"
+     ]
+    }
+   ],
+   "source": [
+    "# SET n.prop = row.col is refused at analyse time:\n",
+    "# \"Cannot evaluate property: types 'String' and 'Invalid' are incompatible\"\n",
+    "# row.Col values have type 'Invalid' in the LOAD CSV context — they cannot be assigned to properties.\n",
+    "try:\n",
+    "    client.new_change()\n",
+    "    client.query(\"LOAD CSV 'tfl_tube.csv' WITH HEADERS AS row CREATE (n:Station) SET n.type = row.Line\")\n",
+    "    client.query('CHANGE SUBMIT')\n",
+    "    client.checkout()\n",
+    "except Exception as e:\n",
+    "    client.checkout()\n",
+    "    print(f'Expected error: {e}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "117914a4",
+   "metadata": {},
+   "source": [
+    "### WHERE row.Col = 'value' — fails (parse error)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "b6573084",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Expected error: PARSE_ERROR: -------* Cypher parser\n",
+      "     1 | LOAD CSV 'tfl_tube.csv' WITH HEADERS AS row WHERE row.Line = 'Bakerloo' RETURN row.From_Station LIMIT 3\n",
+      "       |                                             ^^^^^\n",
+      "-------* syntax error, unexpected WHERE\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    client.query(\"LOAD CSV 'tfl_tube.csv' WITH HEADERS AS row WHERE row.Line = 'Bakerloo' RETURN row.From_Station LIMIT 3\")\n",
+    "except Exception as e:\n",
+    "    print(f'Expected error: {e}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "92da2d47",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Conclusion\n",
+    "\n",
+    "`LOAD CSV` in TuringDB v1.23 is a **read-only CSV inspector + skeleton node creator**:\n",
+    "\n",
+    "- ✅ `RETURN row.Col` — read and preview CSV data (no graph write needed)\n",
+    "- ✅ `CREATE (n:Label)` inside a write transaction — bulk-creates labeled empty nodes (one per row)\n",
+    "- ❌ Properties from `row` cannot be set on nodes/edges (type system limitation: `row.Col` has type `Invalid`)\n",
+    "- ❌ `WHERE`, `MERGE`, inline property maps `{prop: row.Col}` are not supported\n",
+    "\n",
+    "**Practical impact:** LOAD CSV cannot replace LOAD JSONL for data ingestion. All existing example notebooks should continue using LOAD JSONL. LOAD CSV is only useful for quick inspection of CSV contents."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6e54f569-9f09-40d2-80a6-664a4ede7d68",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Saves `TEST_LOAD_CSV.ipynb` to `examples/notebooks/exploration/` — a reference notebook documenting the current state of `LOAD CSV` in TuringDB. Not intended for `main`.